### PR TITLE
Potential fix for code scanning alert no. 12: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/code/src/Attendee/Attendee.cs
+++ b/code/src/Attendee/Attendee.cs
@@ -9,7 +9,12 @@ namespace Attendees
     {
         public void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath))
+            {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
         


### PR DESCRIPTION
Potential fix for [https://github.com/rob99414/skills-secure-repository-supply-chain/security/code-scanning/12](https://github.com/rob99414/skills-secure-repository-supply-chain/security/code-scanning/12)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. The best way to fix this is to:
1. Use `Path.GetFullPath` to resolve any directory traversal elements in the combined path.
2. Use `Path.GetFullPath` on the destination directory to get its fully resolved path.
3. Validate that the resolved output path starts with the resolved destination directory path.
4. Abort the extraction if the validation fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
